### PR TITLE
Rule changes

### DIFF
--- a/src/stylelint-config.js
+++ b/src/stylelint-config.js
@@ -2,9 +2,7 @@ var configs = {
   "plugins": [
     "./plugins/no-at-debug",
     "./plugins/import-path-leading-underscore",
-    "./plugins/import-path-filename-extension",
     "./plugins/else-placement",
-    "./plugins/declaration-block-max-declarations",
     "./plugins/name-format",
     "./plugins/url-format"
   ],
@@ -72,9 +70,7 @@ var configs = {
     },
     "plugin/no-at-debug": true,
     "plugin/import-path-leading-underscore": false,
-    "plugin/import-path-filename-extension": false,
     "plugin/else-placement": 'same-line',
-    "plugin/declaration-block-max-declarations": 10,
     "plugin/name-format": {
       'allow-leading-underscore': false,
       'convention': 'hyphenated-lowercase'
@@ -95,14 +91,14 @@ var configs = {
     "selector-pseudo-class-case": "lower",
     "selector-pseudo-class-parentheses-space-inside": "never",
     "selector-pseudo-element-case": "lower",
-    "selector-pseudo-element-colon-notation": "double",
+    "selector-pseudo-element-colon-notation": false,
     "selector-pseudo-element-no-unknown": true,
     "selector-type-case": "lower",
     "string-no-newline": true,
     "string-quotes": "single",
     "unit-case": "lower",
     "unit-no-unknown": true,
-    "value-list-comma-newline-after": "never-multi-line",
+    "value-list-comma-newline-after": "always-multi-line",
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-space-before": "never"
   }

--- a/src/stylelint-config.js
+++ b/src/stylelint-config.js
@@ -68,7 +68,7 @@ var configs = {
     "number-zero-length-no-unit": true,
     "property-case": "lower",
     "property-value-whitelist": {
-      "color": ["/^$/"]
+      "color": ["/(\$|\#)/"]
     },
     "plugin/no-at-debug": true,
     "plugin/import-path-leading-underscore": false,


### PR DESCRIPTION
All the following rules I've changed are based on what I found
in the guide, that were probably being mis-represented in the scss
-lint config.
- `import-path-filename-extension`: Webpack often needs file extensions to
  function correctly, so I think this rule should be turned off.
- `declaration-block-max-declarations`: we don't actually specify anywhere
  in the guide that you cannot have more then 10 declarations. I think
  this was mistakenly brought in from another config.
- `selector-pseudo-element-colon-notation`: saying two colons isn't
  specified in the guide so I took it out. Is it required at all?
- `value-list-comma-newline-after`: this was changed to what I think we
  wanted it to be.
- `property-value-whitelist,color`: this didn't seemed to be configured correctly
  because it was failing on a var: `$color-something`. I think the guide also
  stipulates that you only need to use a var if the color is used more then once
  so I proposed changing this to either.

Ran the tests and they passed.
