### PR TITLE
Get global binary to be easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,14 @@ gulp.task('my-lint-task', lintFunction);
 The linter can also be run using the command line. The script is installed in
 the .bin folder of your node_modules directory. The only required argument to the script is a glob of directories (or path to a single file) to be linted.
 
-For example: `node node_modules/.bin/stylelint-rules "./path/to/sass/**/*.scss"`
+For example: `node_modules/.bin/18f-stylelint-rules "./path/to/sass/**/*.scss"`
 
 Additionally, the CLI exposes the following options:
 
 ```
 -s, --syntax [scss|css|less], Linter syntax. Defaults to scss.
 -i, --ignore-files [string], Glob of directories or files to ignore
--r, --formatter [verbose|json|string], Output formatter. Defaults to verbose.
+-f, --formatter [verbose|json|string], Output formatter. Defaults to verbose.
 -c, --config [rules], Path to a js file that exports an object describing additional rules.
 ```
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -10,7 +10,7 @@ program
   .usage('[options] <fileString>')
   .option('-s, --syntax <scss|css|less>', 'Linter syntax. Defaults to scss.')
   .option('-i, --ignore-files <string>', 'Glob of directories or files to ignore')
-  .option('-r, --formatter <verbose|json|string>', 'Output formatter. Defaults to verbose.')
+  .option('-f, --formatter <verbose|json|string>', 'Output formatter. Defaults to verbose.')
   .option('-c, --config <rules>', 'Path to a js file that exports an object describing additional rules.')
   .parse(process.argv);
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,3 +1,4 @@
+#!/bin/env node
 var program = require('commander');
 var path = require('path');
 var stylelint = require('stylelint');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A style (CSS, Sass) linter for the 18F style guide",
   "main": "index.js",
   "bin": {
-    "@18f/stylelint-rules": "bin/cli.js"
+    "18f-stylelint-rules": "bin/cli.js"
   },
   "scripts": {
     "test": "node bin/test-runner.js",

--- a/src/stylelint-config.js
+++ b/src/stylelint-config.js
@@ -65,7 +65,7 @@ var configs = {
     "no-invalid-double-slash-comments": true,
     "number-no-trailing-zeros": true,
     "property-case": "lower",
-    "property-value-whitelist": {
+    "declaration-property-value-whitelist": {
       "/color/": ["/(\$|\#)/"]
     },
     "plugin/no-at-debug": true,

--- a/src/stylelint-config.js
+++ b/src/stylelint-config.js
@@ -46,9 +46,10 @@ var configs = {
     "function-max-empty-lines": 0,
     "function-name-case": "lower",
     "function-parentheses-space-inside": "never-single-line",
-    "function-url-quotes": "single",
+    "function-url-quotes": "always",
     "function-whitespace-after": "always",
     "indentation": 2,
+    "length-zero-no-unit": true,
     "max-empty-lines": 1,
     "max-nesting-depth": 4,
     "media-feature-colon-space-after": "always",
@@ -63,10 +64,9 @@ var configs = {
     "no-extra-semicolons": true,
     "no-invalid-double-slash-comments": true,
     "number-no-trailing-zeros": true,
-    "number-zero-length-no-unit": true,
     "property-case": "lower",
     "property-value-whitelist": {
-      "color": ["/(\$|\#)/"]
+      "/color/": ["/(\$|\#)/"]
     },
     "plugin/no-at-debug": true,
     "plugin/import-path-leading-underscore": false,
@@ -91,7 +91,6 @@ var configs = {
     "selector-pseudo-class-case": "lower",
     "selector-pseudo-class-parentheses-space-inside": "never",
     "selector-pseudo-element-case": "lower",
-    "selector-pseudo-element-colon-notation": false,
     "selector-pseudo-element-no-unknown": true,
     "selector-type-case": "lower",
     "string-no-newline": true,


### PR DESCRIPTION
I did some work here to get 18f stylelint to work with being check automatically with vim's Syntastic. Here's what I had to do:
- Change the name of the bin so it's not prefixed with `@18f/`. This would've made it impossible to call as a bin file when it was installed globally.
- Added node env to file so it runs as a node program.
- Fix deprecation warnings, this could be done separately.
- Changing one of the program params back to `stylelint`s default as this is what callers would expect.

I was then able to add `18f-stylelint-rules` as the exec in my Syntastic settings and it all worked:

```
call g:SyntasticRegistry.CreateAndRegisterChecker({
    \ 'filetype': 'css',
    \ 'name': 'stylelint',
    \ 'exec': '18f-stylelint-rules'})
```
