### PR TITLE
Exit with 1 on error

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -37,6 +37,10 @@ stylelint.lint({
 }).then(function(output) {
   var outputFormatter = formatters[formatter];
   console.log(outputFormatter && outputFormatter(output.results));
+  if (output.errored) {
+    process.exit(1);
+  }
 }).catch(function(err) {
   console.log(err);
+  process.exit(1);
 });


### PR DESCRIPTION
We were finding that the process was exiting with 0, therefore the
build wasn't failing on error. This seems incorrect so changing
it to exit with 1 when errors.
